### PR TITLE
Always allow manual updates for errored feeds

### DIFF
--- a/app/Controllers/feedController.php
+++ b/app/Controllers/feedController.php
@@ -487,15 +487,21 @@ class FreshRSS_feed_Controller extends FreshRSS_ActionController {
 				$ttl = FreshRSS_Context::userConf()->ttl_default;
 			}
 			if ($simplePiePush === null && $feed_id === null && (time() <= $feed->lastUpdate() + $ttl)) {
-				//Too early to refresh from source, but check whether the feed was updated by another user
-				$ε = 10;	// negligible offset errors in seconds
-				if ($mtime <= 0 ||
-					$feed->lastUpdate() + $ε >= $mtime ||
-					time() + $ε >= $mtime + FreshRSS_Context::systemConf()->limits['cache_duration']) {	// is cache still valid?
-					continue;	//Nothing newer from other users
+				// For manual updates, always retry feeds in error state regardless of TTL
+				if ($feed->inError()) {
+					Minz_Log::debug('Manual update: retrying feed in error state: ' . $feed->url(false));
+					// Skip TTL check for error feeds - let them be processed
+				} else {
+					//Too early to refresh from source, but check whether the feed was updated by another user
+					$ε = 10;	// negligible offset errors in seconds
+					if ($mtime <= 0 ||
+						$feed->lastUpdate() + $ε >= $mtime ||
+						time() + $ε >= $mtime + FreshRSS_Context::systemConf()->limits['cache_duration']) {	// is cache still valid?
+						continue;	//Nothing newer from other users
+					}
+					Minz_Log::debug('Feed ' . $feed->url(false) . ' was updated at ' . date('c', $feed->lastUpdate()) .
+						', and at ' . date('c', $mtime) . ' by another user; take advantage of newer cache.');
 				}
-				Minz_Log::debug('Feed ' . $feed->url(false) . ' was updated at ' . date('c', $feed->lastUpdate()) .
-					', and at ' . date('c', $mtime) . ' by another user; take advantage of newer cache.');
 			}
 
 			if (!$feed->lock()) {


### PR DESCRIPTION
I'd like to be able to click "Update feeds" and at least attempt to resolve errored feeds. I'm never sure why it is the case, but for these I manually go into their settings and click "Reload articles", which always does the trick.

Obviously sometimes feeds are actually nuked and gone for good, but in my experience they're usually not!